### PR TITLE
fix(extensions): preserve active provider on install

### DIFF
--- a/__tests__/Extensions.test.tsx
+++ b/__tests__/Extensions.test.tsx
@@ -25,8 +25,21 @@ const newProvider = {
   installed: false,
 };
 
+const alternateSourceProvider = {
+  ...existingProvider,
+  source: {author: 'alternate', url: 'https://example.test/alternate'},
+  installed: false,
+};
+
+const secondProvider = {
+  ...newProvider,
+  value: 'second-provider',
+  display_name: 'Second Provider',
+};
+
 let mockActiveProvider = existingProvider;
 let mockInstalledProviders = [existingProvider];
+let mockAvailableProviders = [newProvider];
 const mockSetProvider = jest.fn();
 const mockSetInstalledProviders = jest.fn();
 const mockSetAvailableProviders = jest.fn();
@@ -38,18 +51,19 @@ jest.mock('../src/lib/zustand/themeStore', () => ({
     selector({primary: '#ff6b57'}),
 }));
 
-jest.mock('../src/lib/zustand/contentStore', () => ({
-  __esModule: true,
-  default: (selector: (state: unknown) => unknown) =>
-    selector({
-      provider: mockActiveProvider,
-      setProvider: mockSetProvider,
-      installedProviders: mockInstalledProviders,
-      availableProviders: [newProvider],
-      setInstalledProviders: mockSetInstalledProviders,
-      setAvailableProviders: mockSetAvailableProviders,
-    }),
-}));
+jest.mock('../src/lib/zustand/contentStore', () => {
+  const store = (selector: (state: unknown) => unknown) =>
+    selector(store.getState());
+  store.getState = () => ({
+    provider: mockActiveProvider,
+    setProvider: mockSetProvider,
+    installedProviders: mockInstalledProviders,
+    availableProviders: mockAvailableProviders,
+    setInstalledProviders: mockSetInstalledProviders,
+    setAvailableProviders: mockSetAvailableProviders,
+  });
+  return {__esModule: true, default: store};
+});
 
 jest.mock('../src/lib/storage/extensionStorage', () => ({
   extensionStorage: {
@@ -58,7 +72,7 @@ jest.mock('../src/lib/storage/extensionStorage', () => ({
       url: 'https://example.test/fixture',
     })),
     getInstalledProviders: jest.fn(() => mockInstalledProviders),
-    getAvailableProviders: jest.fn(() => [newProvider]),
+    getAvailableProviders: jest.fn(() => mockAvailableProviders),
     isProviderInstalled: jest.fn(() => false),
   },
 }));
@@ -110,7 +124,11 @@ describe('Extensions provider installation', () => {
     jest.useFakeTimers();
     mockActiveProvider = existingProvider;
     mockInstalledProviders = [existingProvider];
+    mockAvailableProviders = [newProvider];
     mockSetProvider.mockClear();
+    mockSetProvider.mockImplementation(provider => {
+      mockActiveProvider = provider;
+    });
     mockSetInstalledProviders.mockClear();
     mockSetAvailableProviders.mockClear();
     mockInstallProvider.mockReset();
@@ -220,6 +238,121 @@ describe('Extensions provider installation', () => {
         .props.onPress();
     });
 
+    expect(mockSetProvider).toHaveBeenCalledWith(newProvider);
+  });
+
+  it('replaces an active provider that is no longer installed', async () => {
+    mockInstalledProviders = [];
+    mockInstallProvider.mockImplementation(async () => {
+      mockInstalledProviders = [{...newProvider, installed: true}];
+    });
+
+    await act(async () => {
+      tree = renderer.create(
+        <Extensions
+          navigation={{navigate: jest.fn()} as never}
+          route={{} as never}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await tree!.root
+        .findByProps({testID: 'install-provider-fixture:slow-provider'})
+        .props.onPress();
+    });
+
+    expect(mockSetProvider).toHaveBeenCalledWith(newProvider);
+  });
+
+  it('updates provider source identity for a same-value install', async () => {
+    mockAvailableProviders = [alternateSourceProvider];
+    mockInstallProvider.mockImplementation(async () => {
+      mockInstalledProviders = [
+        existingProvider,
+        {...alternateSourceProvider, installed: true},
+      ];
+    });
+
+    await act(async () => {
+      tree = renderer.create(
+        <Extensions
+          navigation={{navigate: jest.fn()} as never}
+          route={{} as never}
+        />,
+      );
+    });
+
+    act(() => {
+      tree!.root
+        .findByProps({testID: 'available-providers-tab'})
+        .props.onPress();
+    });
+
+    await act(async () => {
+      await tree!.root
+        .findByProps({testID: 'install-provider-alternate:existing'})
+        .props.onPress();
+    });
+
+    expect(mockSetProvider).toHaveBeenCalledWith(alternateSourceProvider);
+  });
+
+  it('does not let a later concurrent install replace the first active provider', async () => {
+    mockActiveProvider = {...existingProvider, value: '', display_name: ''};
+    mockInstalledProviders = [];
+    mockAvailableProviders = [newProvider, secondProvider];
+
+    let finishFirstInstall: (() => void) | undefined;
+    let finishSecondInstall: (() => void) | undefined;
+    mockInstallProvider.mockImplementation(
+      provider =>
+        new Promise<void>(resolve => {
+          const finishInstall = () => {
+            mockInstalledProviders = [
+              ...mockInstalledProviders,
+              {...provider, installed: true},
+            ];
+            resolve();
+          };
+          if (provider.value === newProvider.value) {
+            finishFirstInstall = finishInstall;
+          } else {
+            finishSecondInstall = finishInstall;
+          }
+        }),
+    );
+
+    await act(async () => {
+      tree = renderer.create(
+        <Extensions
+          navigation={{navigate: jest.fn()} as never}
+          route={{} as never}
+        />,
+      );
+    });
+
+    let firstInstall: Promise<void>;
+    let secondInstall: Promise<void>;
+    act(() => {
+      firstInstall = tree!.root
+        .findByProps({testID: 'install-provider-fixture:slow-provider'})
+        .props.onPress();
+      secondInstall = tree!.root
+        .findByProps({testID: 'install-provider-fixture:second-provider'})
+        .props.onPress();
+    });
+
+    await act(async () => {
+      finishFirstInstall!();
+      await firstInstall!;
+    });
+    await act(async () => {
+      finishSecondInstall!();
+      await secondInstall!;
+    });
+
+    expect(mockSetProvider).toHaveBeenCalledTimes(1);
     expect(mockSetProvider).toHaveBeenCalledWith(newProvider);
   });
 });

--- a/__tests__/Extensions.test.tsx
+++ b/__tests__/Extensions.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import {Alert} from 'react-native';
+import renderer, {act} from 'react-test-renderer';
+import Extensions from '../src/screens/settings/Extensions';
+
+const existingProvider = {
+  value: 'existing',
+  display_name: 'Existing',
+  source: {author: 'fixture', url: 'https://example.test/fixture'},
+  version: '1.0',
+  icon: '',
+  disabled: false,
+  type: 'global' as const,
+  installed: true,
+};
+
+const newProvider = {
+  value: 'slow-provider',
+  display_name: 'Slow Provider',
+  source: {author: 'fixture', url: 'https://example.test/fixture'},
+  version: '1.3',
+  icon: '',
+  disabled: false,
+  type: 'english' as const,
+  installed: false,
+};
+
+let mockActiveProvider = existingProvider;
+let mockInstalledProviders = [existingProvider];
+const mockSetProvider = jest.fn();
+const mockSetInstalledProviders = jest.fn();
+const mockSetAvailableProviders = jest.fn();
+const mockInstallProvider = jest.fn();
+
+jest.mock('../src/lib/zustand/themeStore', () => ({
+  __esModule: true,
+  default: (selector: (state: {primary: string}) => unknown) =>
+    selector({primary: '#ff6b57'}),
+}));
+
+jest.mock('../src/lib/zustand/contentStore', () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({
+      provider: mockActiveProvider,
+      setProvider: mockSetProvider,
+      installedProviders: mockInstalledProviders,
+      availableProviders: [newProvider],
+      setInstalledProviders: mockSetInstalledProviders,
+      setAvailableProviders: mockSetAvailableProviders,
+    }),
+}));
+
+jest.mock('../src/lib/storage/extensionStorage', () => ({
+  extensionStorage: {
+    getProviderSource: jest.fn(() => ({
+      author: 'fixture',
+      url: 'https://example.test/fixture',
+    })),
+    getInstalledProviders: jest.fn(() => mockInstalledProviders),
+    getAvailableProviders: jest.fn(() => [newProvider]),
+    isProviderInstalled: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../src/lib/services/ExtensionManager', () => ({
+  extensionManager: {
+    initialize: jest.fn(async () => undefined),
+    installProvider: (...args: unknown[]) => mockInstallProvider(...args),
+  },
+}));
+
+jest.mock('../src/lib/services/UpdateProviders', () => ({
+  updateProvidersService: {
+    checkForUpdatesManual: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/lib/storage', () => ({
+  settingsStorage: {
+    isHapticFeedbackEnabled: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../src/screens/settings/components/ProviderSourceManager', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../src/components/RenderProviderFLagIcon', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: () => null,
+  Feather: () => null,
+  FontAwesome6: () => null,
+  MaterialIcons: () => null,
+}));
+
+jest.mock('react-native-haptic-feedback', () => ({
+  trigger: jest.fn(),
+}));
+
+describe('Extensions provider installation', () => {
+  let tree: renderer.ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockActiveProvider = existingProvider;
+    mockInstalledProviders = [existingProvider];
+    mockSetProvider.mockClear();
+    mockSetInstalledProviders.mockClear();
+    mockSetAvailableProviders.mockClear();
+    mockInstallProvider.mockReset();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    act(() => {
+      tree?.unmount();
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the current provider active after installing another provider', async () => {
+    mockInstallProvider.mockImplementation(async () => {
+      mockInstalledProviders = [
+        existingProvider,
+        {...newProvider, installed: true},
+      ];
+    });
+
+    await act(async () => {
+      tree = renderer.create(
+        <Extensions
+          navigation={{navigate: jest.fn()} as never}
+          route={{} as never}
+        />,
+      );
+    });
+
+    act(() => {
+      tree!.root
+        .findByProps({testID: 'available-providers-tab'})
+        .props.onPress();
+    });
+
+    await act(async () => {
+      await tree!.root
+        .findByProps({testID: 'install-provider-fixture:slow-provider'})
+        .props.onPress();
+    });
+
+    expect(mockInstallProvider).toHaveBeenCalledWith(newProvider);
+    expect(mockSetInstalledProviders).toHaveBeenCalledWith(
+      mockInstalledProviders,
+    );
+    expect(mockSetProvider).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Success',
+      'Slow Provider has been installed successfully!',
+    );
+  });
+
+  it('does not change the active provider when installation fails', async () => {
+    mockInstallProvider.mockRejectedValue(new Error('fixture download failed'));
+
+    await act(async () => {
+      tree = renderer.create(
+        <Extensions
+          navigation={{navigate: jest.fn()} as never}
+          route={{} as never}
+        />,
+      );
+    });
+
+    act(() => {
+      tree!.root
+        .findByProps({testID: 'available-providers-tab'})
+        .props.onPress();
+    });
+
+    await act(async () => {
+      await tree!.root
+        .findByProps({testID: 'install-provider-fixture:slow-provider'})
+        .props.onPress();
+    });
+
+    expect(mockSetProvider).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Error',
+      'Failed to install provider. Please try again.',
+    );
+  });
+
+  it('activates the first provider installed during initial setup', async () => {
+    mockActiveProvider = {...existingProvider, value: '', display_name: ''};
+    mockInstalledProviders = [];
+    mockInstallProvider.mockImplementation(async () => {
+      mockInstalledProviders = [{...newProvider, installed: true}];
+    });
+
+    await act(async () => {
+      tree = renderer.create(
+        <Extensions
+          navigation={{navigate: jest.fn()} as never}
+          route={{} as never}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await tree!.root
+        .findByProps({testID: 'install-provider-fixture:slow-provider'})
+        .props.onPress();
+    });
+
+    expect(mockSetProvider).toHaveBeenCalledWith(newProvider);
+  });
+});

--- a/src/screens/settings/Extensions.tsx
+++ b/src/screens/settings/Extensions.tsx
@@ -39,6 +39,12 @@ type Props = NativeStackScreenProps<SettingsStackParamList, 'Extensions'>;
 
 type TabType = 'installed' | 'available';
 
+const isSameProvider = (
+  left: ProviderExtension | undefined,
+  right: ProviderExtension,
+) =>
+  left?.value === right.value && left.source?.author === right.source?.author;
+
 const Extensions = ({navigation}: Props) => {
   const {primary} = useThemeStore(state => state);
   const {
@@ -191,10 +197,27 @@ const Extensions = ({navigation}: Props) => {
         'Success',
         `${provider.display_name} has been installed successfully!`,
       );
-      setInstalledProviders(extensionStorage.getInstalledProviders() || []);
+      const refreshedInstalledProviders =
+        extensionStorage.getInstalledProviders() || [];
+      setInstalledProviders(refreshedInstalledProviders);
+
       // Keep the current provider active. Switching here can immediately run
       // newly downloaded provider code in mounted screens and block the UI.
-      if (!activeExtensionProvider?.value) {
+      // Read after the download so concurrent installs cannot act on a stale
+      // provider captured when their handlers started.
+      const currentProvider = useContentStore.getState().provider;
+      const currentProviderIsInstalled = refreshedInstalledProviders.some(
+        installedProvider => isSameProvider(installedProvider, currentProvider),
+      );
+      const installedSameValueFromAnotherSource =
+        currentProvider?.value === provider.value &&
+        currentProvider.source?.author !== provider.source?.author;
+
+      if (
+        !currentProvider?.value ||
+        !currentProviderIsInstalled ||
+        installedSameValueFromAnotherSource
+      ) {
         setActiveExtensionProvider(provider);
       }
     } catch (error) {

--- a/src/screens/settings/Extensions.tsx
+++ b/src/screens/settings/Extensions.tsx
@@ -192,11 +192,9 @@ const Extensions = ({navigation}: Props) => {
         `${provider.display_name} has been installed successfully!`,
       );
       setInstalledProviders(extensionStorage.getInstalledProviders() || []);
-      if (
-        !activeExtensionProvider ||
-        activeExtensionProvider.value !== provider.value ||
-        activeExtensionProvider.source?.author !== provider.source?.author
-      ) {
+      // Keep the current provider active. Switching here can immediately run
+      // newly downloaded provider code in mounted screens and block the UI.
+      if (!activeExtensionProvider?.value) {
         setActiveExtensionProvider(provider);
       }
     } catch (error) {
@@ -417,6 +415,7 @@ const Extensions = ({navigation}: Props) => {
               </>
             ) : (
               <TouchableOpacity
+                testID={`install-provider-${itemKey}`}
                 onPress={() => handleInstallProvider(item)}
                 disabled={isInstalled || isInstalling}
                 className={'w-9 h-9 rounded-full items-center justify-center'}
@@ -476,6 +475,7 @@ const Extensions = ({navigation}: Props) => {
         </TouchableOpacity>
 
         <TouchableOpacity
+          testID="available-providers-tab"
           onPress={() => handleTabChange('available')}
           className="flex-1 py-3 rounded-xl"
           style={{


### PR DESCRIPTION
## Summary

- keep the currently selected provider active when another provider is installed
- preserve first-install behavior by selecting a provider only when no provider is active
- add mocked UI regression coverage for successful, failed, and first-time installs

## Why

The install handler previously changed the global active provider immediately after persisting the downloaded modules. Mounted Home consumers then synchronously evaluate the new provider catalog before asynchronous request error handling can run. For a slow provider, native scrolling can continue while JavaScript-backed press handlers stop responding, matching the issue reproduction.

Closes #492.

## Validation

- `jest __tests__/Extensions.test.tsx --runInBand`: 3 passed
- Jest excluding the pre-existing `App.test.tsx` CSS-loader failure: 14 suites, 74 tests passed
- ESLint on changed files with `--quiet`: passed
- Prettier on changed files: passed

## Existing baseline failures

- full Jest cannot parse `src/global.css` from `App.test.tsx`
- full ESLint reports three unrelated unused-variable errors in `useContentInfo.ts`, `helpers.ts`, and `Search.tsx`