### PR TITLE
Fix: saving local video file's location and time

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -22,6 +22,7 @@ module.exports = () => {
     './plugins/with-custom-native-modules.js',
     './plugins/android-native-config.js',
     './plugins/with-saf-copy-module.js',
+    './plugins/with-uri-permission-module.js',
     './plugins/with-proguard-rules.js',
     './plugins/with-jvm-args.js',
     './plugins/with-android-notification-icons.js',

--- a/plugins/with-uri-permission-module.js
+++ b/plugins/with-uri-permission-module.js
@@ -1,0 +1,124 @@
+const fs = require('fs');
+const path = require('path');
+const {withDangerousMod, withMainApplication} = require('expo/config-plugins');
+
+const URI_PERMISSION_MODULE_SOURCE = packageName => `package ${packageName}
+
+import android.content.Intent
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.ReactPackage
+import com.facebook.react.uimanager.ViewManager
+import android.net.Uri
+
+// Lets JS ask Android to persist read access to a document picked via the
+// Storage Access Framework (ACTION_OPEN_DOCUMENT), so a content:// uri
+// handed back by expo-document-picker (with copyToCacheDirectory: false)
+// stays readable after the app process is killed and restarted, without
+// duplicating the underlying file. Without this call, the grant Android
+// hands out for a freshly-picked document is not guaranteed to survive
+// past the current process lifetime.
+class UriPermissionModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName(): String = "UriPermissionModule"
+
+  @ReactMethod
+  fun takePersistableUriPermission(uriString: String, promise: Promise) {
+    try {
+      val uri = Uri.parse(uriString)
+      val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+      reactContext.contentResolver.takePersistableUriPermission(uri, flags)
+      promise.resolve(true)
+    } catch (error: Exception) {
+      // Non-fatal: some uris (e.g. already-persisted, or from providers
+      // that don't support persistable grants) will throw here. The
+      // caller should treat this as "couldn't guarantee persistence"
+      // rather than a hard failure.
+      promise.reject("TAKE_PERSISTABLE_URI_PERMISSION_FAILED", error.message, error)
+    }
+  }
+
+  @ReactMethod
+  fun releasePersistableUriPermission(uriString: String, promise: Promise) {
+    try {
+      val uri = Uri.parse(uriString)
+      val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+      reactContext.contentResolver.releasePersistableUriPermission(uri, flags)
+      promise.resolve(true)
+    } catch (error: Exception) {
+      // Already released, or never held — safe to ignore from JS's
+      // perspective, so resolve false instead of rejecting.
+      promise.resolve(false)
+    }
+  }
+
+  @ReactMethod
+  fun getPersistedUriPermissions(promise: Promise) {
+    try {
+      val uris = reactContext.contentResolver.persistedUriPermissions.map { it.uri.toString() }
+      promise.resolve(com.facebook.react.bridge.Arguments.fromList(uris))
+    } catch (error: Exception) {
+      promise.reject("GET_PERSISTED_URI_PERMISSIONS_FAILED", error.message, error)
+    }
+  }
+}
+
+class UriPermissionPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+    return listOf(UriPermissionModule(reactContext))
+  }
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+    return emptyList()
+  }
+}
+`;
+
+function withUriPermissionModule(config) {
+  config = withDangerousMod(config, [
+    'android',
+    async cfg => {
+      const projectRoot = cfg.modRequest.projectRoot;
+      const packageName = cfg.android?.package || 'com.vega';
+      const packagePath = packageName.replace(/\./g, '/');
+      const targetFile = path.join(
+        projectRoot,
+        'android',
+        'app',
+        'src',
+        'main',
+        'java',
+        packagePath,
+        'UriPermissionModule.kt',
+      );
+
+      fs.mkdirSync(path.dirname(targetFile), {recursive: true});
+      fs.writeFileSync(
+        targetFile,
+        URI_PERMISSION_MODULE_SOURCE(packageName),
+        'utf8',
+      );
+
+      return cfg;
+    },
+  ]);
+
+  return withMainApplication(config, cfg => {
+    const currentContents = cfg.modResults.contents;
+
+    if (!currentContents.includes('add(UriPermissionPackage())')) {
+      const updatedContents = currentContents.replace(
+        /PackageList\(this\)\.packages\.apply \{\n/,
+        match => `${match}              add(UriPermissionPackage())\n`,
+      );
+
+      cfg.modResults.contents = updatedContents;
+    }
+
+    return cfg;
+  });
+}
+
+module.exports = withUriPermissionModule;

--- a/src/lib/hooks/useStream.ts
+++ b/src/lib/hooks/useStream.ts
@@ -1,10 +1,11 @@
 import {useQuery} from '@tanstack/react-query';
-import {useState, useEffect, useMemo} from 'react';
+import {useState, useEffect, useMemo, useRef} from 'react';
 import {ToastAndroid} from 'react-native';
 import {providerManager} from '../services/ProviderManager';
 import {settingsStorage} from '../storage';
 import {ifExists} from '../file/ifExists';
 import {Stream} from '../providers/types';
+import {getEpisodeIdentity} from '../utils/episodeIdentity';
 
 interface UseStreamOptions {
   activeEpisode: any;
@@ -25,6 +26,23 @@ export const useStream = ({
     type: '',
   });
   const [externalSubs, setExternalSubs] = useState<any[]>([]);
+
+  // A locally-picked/auto-resumed video file is only ever valid for the
+  // episode it was picked for. Whenever the active episode changes, clear
+  // the selection back to neutral so the stream-data effect below falls
+  // through to picking the new episode's first online stream, instead of
+  // silently carrying over the old episode's local file (see the
+  // 'local' guard further down).
+  const activeEpisodeKey = getEpisodeIdentity(activeEpisode);
+  const previousEpisodeKeyRef = useRef(activeEpisodeKey);
+
+  useEffect(() => {
+    if (previousEpisodeKeyRef.current === activeEpisodeKey) {
+      return;
+    }
+    previousEpisodeKeyRef.current = activeEpisodeKey;
+    setSelectedStream({server: '', link: '', type: ''});
+  }, [activeEpisodeKey]);
 
   const {
     data: streamData = [],

--- a/src/lib/hooks/useStream.ts
+++ b/src/lib/hooks/useStream.ts
@@ -104,6 +104,9 @@ export const useStream = ({
     if (streamData && streamData.length > 0) {
       setSelectedStream(current => {
         if (!current?.link) return streamData[0];
+        // A locally-picked (or auto-resumed) video file will never match an
+        // online stream link — that's expected, not staleness. Leave it be.
+        if (current?.type === 'local') return current;
         const stillExists = streamData.find(s => s.link === current.link);
         return stillExists ? current : streamData[0];
       });
@@ -197,7 +200,6 @@ export const useVideoSettings = () => {
   };
 
   const processVideoTracks = (tracks: any[]) => {
-
     if (!tracks || tracks.length === 0) {
       return;
     }
@@ -210,10 +212,9 @@ export const useVideoSettings = () => {
       }
       return false;
     });
-        console.log('Processing video tracks:', uniqueTracks);
+    console.log('Processing video tracks:', uniqueTracks);
     setVideoTracks(uniqueTracks);
   };
-
 
   const handleVideoLoad = (naturalSize?: {width?: number; height?: number}) => {
     if (!naturalSize?.height) {
@@ -230,7 +231,6 @@ export const useVideoSettings = () => {
     setVideoTracks([]);
     setLoadedVideoSize(null);
   };
-
 
   const effectiveVideoTracks = useMemo(() => {
     if (videoTracks.length > 0) {

--- a/src/lib/uriPermission.ts
+++ b/src/lib/uriPermission.ts
@@ -1,0 +1,55 @@
+import {NativeModules, Platform} from 'react-native';
+
+type UriPermissionModuleType = {
+  takePersistableUriPermission: (uri: string) => Promise<boolean>;
+  releasePersistableUriPermission: (uri: string) => Promise<boolean>;
+  getPersistedUriPermissions: () => Promise<string[]>;
+};
+
+const getUriPermissionModule = (): UriPermissionModuleType | undefined =>
+  NativeModules.UriPermissionModule as UriPermissionModuleType | undefined;
+
+// Ask Android to remember read access to a SAF (content://) uri across app
+// restarts, without copying the underlying file. Used for locally-picked
+// video files so multi-gigabyte movies/episodes don't have to be duplicated
+// into app cache just to survive being resumed from Continue Watching.
+//
+// Resolves to false (never throws) if the grant couldn't be persisted —
+// callers should treat that as "this session only" rather than an error,
+// since some content providers don't support persistable permissions.
+export const takePersistableUriPermission = async (
+  uri: string,
+): Promise<boolean> => {
+  if (Platform.OS !== 'android' || !uri?.startsWith('content://')) {
+    return false;
+  }
+  try {
+    const module = getUriPermissionModule();
+    if (!module?.takePersistableUriPermission) {
+      return false;
+    }
+    await module.takePersistableUriPermission(uri);
+    return true;
+  } catch (error) {
+    console.warn('Failed to persist uri permission for', uri, error);
+    return false;
+  }
+};
+
+// Frees a previously-persisted grant. Android only allows a limited number
+// of persisted uri permissions per app, so we release the old one whenever
+// the user picks a different local file or switches away from local
+// playback for an episode.
+export const releasePersistableUriPermission = async (
+  uri?: string,
+): Promise<void> => {
+  if (!uri || Platform.OS !== 'android' || !uri.startsWith('content://')) {
+    return;
+  }
+  try {
+    const module = getUriPermissionModule();
+    await module?.releasePersistableUriPermission?.(uri);
+  } catch (error) {
+    console.warn('Failed to release uri permission for', uri, error);
+  }
+};

--- a/src/lib/utils/episodeIdentity.ts
+++ b/src/lib/utils/episodeIdentity.ts
@@ -11,3 +11,22 @@ export interface EpisodeIdentityLike {
 
 export const getEpisodeIdentity = (episode?: EpisodeIdentityLike): string =>
   episode?.sourceLink || episode?.id || episode?.link || '';
+
+export const getLocalVideoAssociationKey = ({
+  episode,
+  provider,
+  infoUrl,
+}: {
+  episode?: EpisodeIdentityLike;
+  provider?: string;
+  infoUrl?: string;
+}): string => {
+  const episodeIdentity = getEpisodeIdentity(episode);
+  if (!episodeIdentity) {
+    return '';
+  }
+
+  return [provider || '', infoUrl || '', episodeIdentity]
+    .map(part => encodeURIComponent(part))
+    .join('|');
+};

--- a/src/lib/utils/episodeIdentity.ts
+++ b/src/lib/utils/episodeIdentity.ts
@@ -1,0 +1,13 @@
+// A stable identity for an episode/movie link, used anywhere we need to
+// know whether "this is the same thing being watched" across renders,
+// hooks, or persisted storage (e.g. continue-watching sync, local-video
+// associations). Kept in one place so every consumer agrees on the same
+// field-priority order.
+export interface EpisodeIdentityLike {
+  sourceLink?: string;
+  id?: string;
+  link?: string;
+}
+
+export const getEpisodeIdentity = (episode?: EpisodeIdentityLike): string =>
+  episode?.sourceLink || episode?.id || episode?.link || '';

--- a/src/lib/zustand/continueWatchingStore.ts
+++ b/src/lib/zustand/continueWatchingStore.ts
@@ -16,22 +16,12 @@ export interface ContinueWatchingItem {
   position: number;
   duration: number;
   updatedAt: number;
-  // When the user picked a local video file for this item, we remember its
-  // uri (and display name) so re-opening it from Continue Watching can
-  // resume playback without prompting the file picker again.
-  localVideoUri?: string;
-  localVideoName?: string;
 }
 
 interface ContinueWatchingState {
   items: ContinueWatchingItem[];
   upsertItem: (item: ContinueWatchingItem) => void;
   updateProgress: (id: string, position: number, duration: number) => void;
-  setLocalVideo: (
-    id: string,
-    localVideoUri?: string,
-    localVideoName?: string,
-  ) => void;
   removeItem: (id: string) => void;
 }
 
@@ -57,12 +47,6 @@ const useContinueWatchingStore = create<ContinueWatchingState>()(
                 : item,
             )
             .sort((a, b) => b.updatedAt - a.updatedAt),
-        })),
-      setLocalVideo: (id, localVideoUri, localVideoName) =>
-        set(state => ({
-          items: state.items.map(item =>
-            item.id === id ? {...item, localVideoUri, localVideoName} : item,
-          ),
         })),
       removeItem: id =>
         set(state => ({items: state.items.filter(item => item.id !== id)})),

--- a/src/lib/zustand/continueWatchingStore.ts
+++ b/src/lib/zustand/continueWatchingStore.ts
@@ -16,12 +16,22 @@ export interface ContinueWatchingItem {
   position: number;
   duration: number;
   updatedAt: number;
+  // When the user picked a local video file for this item, we remember its
+  // uri (and display name) so re-opening it from Continue Watching can
+  // resume playback without prompting the file picker again.
+  localVideoUri?: string;
+  localVideoName?: string;
 }
 
 interface ContinueWatchingState {
   items: ContinueWatchingItem[];
   upsertItem: (item: ContinueWatchingItem) => void;
   updateProgress: (id: string, position: number, duration: number) => void;
+  setLocalVideo: (
+    id: string,
+    localVideoUri?: string,
+    localVideoName?: string,
+  ) => void;
   removeItem: (id: string) => void;
 }
 
@@ -47,6 +57,12 @@ const useContinueWatchingStore = create<ContinueWatchingState>()(
                 : item,
             )
             .sort((a, b) => b.updatedAt - a.updatedAt),
+        })),
+      setLocalVideo: (id, localVideoUri, localVideoName) =>
+        set(state => ({
+          items: state.items.map(item =>
+            item.id === id ? {...item, localVideoUri, localVideoName} : item,
+          ),
         })),
       removeItem: id =>
         set(state => ({items: state.items.filter(item => item.id !== id)})),

--- a/src/lib/zustand/localVideoStore.ts
+++ b/src/lib/zustand/localVideoStore.ts
@@ -1,6 +1,9 @@
 import {create} from 'zustand';
 import {createJSONStorage, persist} from 'zustand/middleware';
 import {createZustandStorage} from '../storage/StorageService';
+import {releasePersistableUriPermission} from '../uriPermission';
+
+const MAX_LOCAL_VIDEO_ASSOCIATIONS = 64;
 
 export interface LocalVideoAssociation {
   // Same value as getEpisodeIdentity(episode) — the episode/movie this
@@ -37,8 +40,9 @@ const useLocalVideoStore = create<LocalVideoState>()(
         if (!episodeKey) {
           return;
         }
-        set(state => ({
-          associations: {
+        set(state => {
+          const previous = state.associations[episodeKey];
+          const associations = {
             ...state.associations,
             [episodeKey]: {
               episodeKey,
@@ -47,8 +51,26 @@ const useLocalVideoStore = create<LocalVideoState>()(
               name,
               updatedAt: Date.now(),
             },
-          },
-        }));
+          };
+
+          if (previous?.uri && previous.uri !== uri) {
+            releasePersistableUriPermission(previous.uri);
+          }
+
+          const entries = Object.entries(associations).sort(
+            ([, a], [, b]) => b.updatedAt - a.updatedAt,
+          );
+          const evicted = entries.slice(MAX_LOCAL_VIDEO_ASSOCIATIONS);
+          evicted.forEach(([, association]) => {
+            releasePersistableUriPermission(association.uri);
+          });
+
+          return {
+            associations: Object.fromEntries(
+              entries.slice(0, MAX_LOCAL_VIDEO_ASSOCIATIONS),
+            ),
+          };
+        });
       },
       clearLocalVideo: episodeKey => {
         if (!episodeKey) {
@@ -59,6 +81,7 @@ const useLocalVideoStore = create<LocalVideoState>()(
             return state;
           }
           const next = {...state.associations};
+          releasePersistableUriPermission(next[episodeKey].uri);
           delete next[episodeKey];
           return {associations: next};
         });

--- a/src/lib/zustand/localVideoStore.ts
+++ b/src/lib/zustand/localVideoStore.ts
@@ -1,0 +1,74 @@
+import {create} from 'zustand';
+import {createJSONStorage, persist} from 'zustand/middleware';
+import {createZustandStorage} from '../storage/StorageService';
+
+export interface LocalVideoAssociation {
+  // Same value as getEpisodeIdentity(episode) — the episode/movie this
+  // local file belongs to.
+  episodeKey: string;
+  // The continue-watching entry this was picked from, kept only for
+  // context/debugging; not relied on for lookups.
+  continueWatchingId?: string;
+  uri: string;
+  name?: string;
+  updatedAt: number;
+}
+
+interface LocalVideoState {
+  associations: Record<string, LocalVideoAssociation>;
+  setLocalVideo: (
+    episodeKey: string,
+    uri: string,
+    name?: string,
+    continueWatchingId?: string,
+  ) => void;
+  clearLocalVideo: (episodeKey: string) => void;
+}
+
+// Intentionally a separate, device-local-only store — NOT part of
+// continueWatchingStore and NOT touched by src/lib/sync/syncService.ts.
+// A local video file only exists on this device, so it should never be
+// carried over (or wiped out) by the cross-device shared-folder sync.
+const useLocalVideoStore = create<LocalVideoState>()(
+  persist(
+    set => ({
+      associations: {},
+      setLocalVideo: (episodeKey, uri, name, continueWatchingId) => {
+        if (!episodeKey) {
+          return;
+        }
+        set(state => ({
+          associations: {
+            ...state.associations,
+            [episodeKey]: {
+              episodeKey,
+              continueWatchingId,
+              uri,
+              name,
+              updatedAt: Date.now(),
+            },
+          },
+        }));
+      },
+      clearLocalVideo: episodeKey => {
+        if (!episodeKey) {
+          return;
+        }
+        set(state => {
+          if (!(episodeKey in state.associations)) {
+            return state;
+          }
+          const next = {...state.associations};
+          delete next[episodeKey];
+          return {associations: next};
+        });
+      },
+    }),
+    {
+      name: 'local-video-storage',
+      storage: createJSONStorage(() => createZustandStorage()),
+    },
+  ),
+);
+
+export default useLocalVideoStore;

--- a/src/screens/home/Player.tsx
+++ b/src/screens/home/Player.tsx
@@ -51,15 +51,15 @@ import {torrentManager} from '../../lib/torrentManager';
 import {syncFromSharedFolder} from '../../lib/sync/syncService';
 import {useM3Colors} from '../../theme/M3PaletteContext';
 import useContinueWatchingStore from '../../lib/zustand/continueWatchingStore';
+import useLocalVideoStore from '../../lib/zustand/localVideoStore';
 import CastRemotePlayer from '../../components/CastRemotePlayer';
+import {getEpisodeIdentity} from '../../lib/utils/episodeIdentity';
+import {
+  takePersistableUriPermission,
+  releasePersistableUriPermission,
+} from '../../lib/uriPermission';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Player'>;
-
-const getEpisodeIdentity = (episode?: {
-  sourceLink?: string;
-  id?: string;
-  link?: string;
-}) => episode?.sourceLink || episode?.id || episode?.link || '';
 
 const readCachedProgress = (link?: string) => {
   if (!link) {
@@ -181,10 +181,16 @@ const Player = ({route}: Props): React.JSX.Element => {
   const updateContinueWatchingProgress = useContinueWatchingStore(
     state => state.updateProgress,
   );
-  const setLocalVideoForContinueWatching = useContinueWatchingStore(
+  const continueWatchingItems = useContinueWatchingStore(state => state.items);
+  const localVideoAssociations = useLocalVideoStore(
+    state => state.associations,
+  );
+  const setLocalVideoAssociation = useLocalVideoStore(
     state => state.setLocalVideo,
   );
-  const continueWatchingItems = useContinueWatchingStore(state => state.items);
+  const clearLocalVideoAssociation = useLocalVideoStore(
+    state => state.clearLocalVideo,
+  );
 
   // Player ref
   const playerRef = useRef<VideoRef>(null as unknown as VideoRef);
@@ -314,6 +320,13 @@ const Player = ({route}: Props): React.JSX.Element => {
   } = usePlayerSettings();
   const isFullScreenRef = useRef(isFullScreen);
   const continueWatchingId = route.params.infoUrl || activeEpisode?.link;
+  const activeEpisodeKey = useMemo(
+    () => getEpisodeIdentity(activeEpisode),
+    [activeEpisode],
+  );
+  const localVideoForEpisode = activeEpisodeKey
+    ? localVideoAssociations[activeEpisodeKey]
+    : undefined;
   const syncedContinueWatching = useMemo(
     () => continueWatchingItems.find(item => item.id === continueWatchingId),
     [continueWatchingId, continueWatchingItems],
@@ -363,12 +376,6 @@ const Player = ({route}: Props): React.JSX.Element => {
       position,
       duration,
       updatedAt: syncedUpdatedAt || (position > 0 ? Date.now() : 0),
-      localVideoUri: syncedEpisodeMatches
-        ? syncedContinueWatching?.localVideoUri
-        : undefined,
-      localVideoName: syncedEpisodeMatches
-        ? syncedContinueWatching?.localVideoName
-        : undefined,
     });
   }, [
     activeEpisode,
@@ -381,8 +388,6 @@ const Player = ({route}: Props): React.JSX.Element => {
     route.params.secondaryTitle,
     route.params.type,
     syncReady,
-    syncedContinueWatching?.localVideoName,
-    syncedContinueWatching?.localVideoUri,
     syncedDuration,
     syncedEpisodeMatches,
     syncedPosition,
@@ -441,21 +446,23 @@ const Player = ({route}: Props): React.JSX.Element => {
   // Auto-resume a remembered local video file for this episode (e.g. when
   // opening this title again from Continue Watching) instead of forcing the
   // user to pick the file again. Only applied once per episode so it never
-  // fights a manual server switch made later in the same session.
+  // fights a manual server switch made later in the same session. Looked up
+  // directly by the current episode's identity, so it can never carry over
+  // a different episode's file.
   useEffect(() => {
     if (appliedPersistedLocalVideoRef.current) {
       return;
     }
-    if (!syncedEpisodeMatches || !syncedContinueWatching?.localVideoUri) {
+    if (!localVideoForEpisode?.uri) {
       return;
     }
     appliedPersistedLocalVideoRef.current = true;
     setSelectedStream({
       server: 'Local Video',
-      link: syncedContinueWatching.localVideoUri,
+      link: localVideoForEpisode.uri,
       type: 'local',
     });
-  }, [syncedContinueWatching, syncedEpisodeMatches, setSelectedStream]);
+  }, [localVideoForEpisode, setSelectedStream]);
 
   useEffect(() => {
     if (
@@ -726,33 +733,46 @@ const Player = ({route}: Props): React.JSX.Element => {
           'video/x-m4v',
         ],
         multiple: false,
-        // Videos can be several gigabytes. Play the provider URI directly
-        // instead of duplicating the complete file in the app cache.
+        // Videos can be several gigabytes. Play the provider uri directly
+        // instead of duplicating the whole file into app cache — Android's
+        // takePersistableUriPermission (below) keeps it readable across
+        // app restarts without a copy.
         copyToCacheDirectory: false,
       });
 
       if (!res.canceled && res.assets?.[0]) {
         const asset = res.assets[0];
+        const previousUri = localVideoForEpisode?.uri;
+
         setSelectedStream({
           server: 'Local Video',
           link: asset.uri,
           type: 'local',
         });
         setShowSettings(false);
-        // Remember this file against the current continue-watching entry so
-        // reopening this same episode later resumes it automatically
+        // Remember this file against the current episode so reopening it
+        // later (e.g. from Continue Watching) resumes it automatically
         // instead of prompting the picker again.
         appliedPersistedLocalVideoRef.current = true;
-        if (continueWatchingId) {
-          setLocalVideoForContinueWatching(
-            continueWatchingId,
+        if (activeEpisodeKey) {
+          setLocalVideoAssociation(
+            activeEpisodeKey,
             asset.uri,
             asset.name || undefined,
+            continueWatchingId,
           );
         }
+
+        const persisted = await takePersistableUriPermission(asset.uri);
+        if (previousUri && previousUri !== asset.uri) {
+          releasePersistableUriPermission(previousUri);
+        }
+
         ToastAndroid.show(
-          `Playing local file: ${asset.name || 'video'}`,
-          ToastAndroid.SHORT,
+          persisted
+            ? `Playing local file: ${asset.name || 'video'}`
+            : `Playing local file: ${asset.name || 'video'} (may need to be re-selected after closing the app)`,
+          ToastAndroid.LONG,
         );
       }
     } catch (err) {
@@ -760,8 +780,10 @@ const Player = ({route}: Props): React.JSX.Element => {
       ToastAndroid.show('Could not open the selected file', ToastAndroid.SHORT);
     }
   }, [
+    activeEpisodeKey,
     continueWatchingId,
-    setLocalVideoForContinueWatching,
+    localVideoForEpisode?.uri,
+    setLocalVideoAssociation,
     setSelectedStream,
     setShowSettings,
   ]);
@@ -1727,12 +1749,13 @@ const Player = ({route}: Props): React.JSX.Element => {
                         onPress={() => {
                           setSelectedStream(track);
                           appliedPersistedLocalVideoRef.current = true;
-                          if (continueWatchingId) {
-                            setLocalVideoForContinueWatching(
-                              continueWatchingId,
-                              undefined,
-                              undefined,
-                            );
+                          if (activeEpisodeKey) {
+                            if (localVideoForEpisode?.uri) {
+                              releasePersistableUriPermission(
+                                localVideoForEpisode.uri,
+                              );
+                            }
+                            clearLocalVideoAssociation(activeEpisodeKey);
                           }
                           setShowSettings(false);
                           playerRef?.current?.resume();

--- a/src/screens/home/Player.tsx
+++ b/src/screens/home/Player.tsx
@@ -53,10 +53,12 @@ import {useM3Colors} from '../../theme/M3PaletteContext';
 import useContinueWatchingStore from '../../lib/zustand/continueWatchingStore';
 import useLocalVideoStore from '../../lib/zustand/localVideoStore';
 import CastRemotePlayer from '../../components/CastRemotePlayer';
-import {getEpisodeIdentity} from '../../lib/utils/episodeIdentity';
+import {
+  getEpisodeIdentity,
+  getLocalVideoAssociationKey,
+} from '../../lib/utils/episodeIdentity';
 import {
   takePersistableUriPermission,
-  releasePersistableUriPermission,
 } from '../../lib/uriPermission';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Player'>;
@@ -321,8 +323,18 @@ const Player = ({route}: Props): React.JSX.Element => {
   const isFullScreenRef = useRef(isFullScreen);
   const continueWatchingId = route.params.infoUrl || activeEpisode?.link;
   const activeEpisodeKey = useMemo(
-    () => getEpisodeIdentity(activeEpisode),
-    [activeEpisode],
+    () =>
+      getLocalVideoAssociationKey({
+        episode: activeEpisode,
+        provider: route.params.providerValue || provider.value,
+        infoUrl: continueWatchingId,
+      }),
+    [
+      activeEpisode,
+      continueWatchingId,
+      provider.value,
+      route.params.providerValue,
+    ],
   );
   const localVideoForEpisode = activeEpisodeKey
     ? localVideoAssociations[activeEpisodeKey]
@@ -712,9 +724,6 @@ const Player = ({route}: Props): React.JSX.Element => {
         // the existing "pick streamData[0] once it arrives" logic in
         // useStream takes over as soon as it resolves.
         if (activeEpisodeKey) {
-          if (selectedStream.link) {
-            releasePersistableUriPermission(selectedStream.link);
-          }
           clearLocalVideoAssociation(activeEpisodeKey);
         }
         appliedPersistedLocalVideoRef.current = true;
@@ -781,8 +790,6 @@ const Player = ({route}: Props): React.JSX.Element => {
 
       if (!res.canceled && res.assets?.[0]) {
         const asset = res.assets[0];
-        const previousUri = localVideoForEpisode?.uri;
-
         setSelectedStream({
           server: 'Local Video',
           link: asset.uri,
@@ -803,9 +810,6 @@ const Player = ({route}: Props): React.JSX.Element => {
         }
 
         const persisted = await takePersistableUriPermission(asset.uri);
-        if (previousUri && previousUri !== asset.uri) {
-          releasePersistableUriPermission(previousUri);
-        }
 
         ToastAndroid.show(
           persisted
@@ -821,7 +825,6 @@ const Player = ({route}: Props): React.JSX.Element => {
   }, [
     activeEpisodeKey,
     continueWatchingId,
-    localVideoForEpisode?.uri,
     setLocalVideoAssociation,
     setSelectedStream,
     setShowSettings,
@@ -1789,11 +1792,6 @@ const Player = ({route}: Props): React.JSX.Element => {
                           setSelectedStream(track);
                           appliedPersistedLocalVideoRef.current = true;
                           if (activeEpisodeKey) {
-                            if (localVideoForEpisode?.uri) {
-                              releasePersistableUriPermission(
-                                localVideoForEpisode.uri,
-                              );
-                            }
                             clearLocalVideoAssociation(activeEpisodeKey);
                           }
                           setShowSettings(false);

--- a/src/screens/home/Player.tsx
+++ b/src/screens/home/Player.tsx
@@ -181,6 +181,9 @@ const Player = ({route}: Props): React.JSX.Element => {
   const updateContinueWatchingProgress = useContinueWatchingStore(
     state => state.updateProgress,
   );
+  const setLocalVideoForContinueWatching = useContinueWatchingStore(
+    state => state.setLocalVideo,
+  );
   const continueWatchingItems = useContinueWatchingStore(state => state.items);
 
   // Player ref
@@ -192,6 +195,7 @@ const Player = ({route}: Props): React.JSX.Element => {
   const loadedCastMediaRef = useRef('');
   const remoteCastPositionRef = useRef(0);
   const wasCastingRef = useRef(false);
+  const appliedPersistedLocalVideoRef = useRef(false);
 
   // Shared values for animations
   const loadingOpacity = useSharedValue(0);
@@ -359,6 +363,12 @@ const Player = ({route}: Props): React.JSX.Element => {
       position,
       duration,
       updatedAt: syncedUpdatedAt || (position > 0 ? Date.now() : 0),
+      localVideoUri: syncedEpisodeMatches
+        ? syncedContinueWatching?.localVideoUri
+        : undefined,
+      localVideoName: syncedEpisodeMatches
+        ? syncedContinueWatching?.localVideoName
+        : undefined,
     });
   }, [
     activeEpisode,
@@ -371,6 +381,8 @@ const Player = ({route}: Props): React.JSX.Element => {
     route.params.secondaryTitle,
     route.params.type,
     syncReady,
+    syncedContinueWatching?.localVideoName,
+    syncedContinueWatching?.localVideoUri,
     syncedDuration,
     syncedEpisodeMatches,
     syncedPosition,
@@ -423,7 +435,27 @@ const Player = ({route}: Props): React.JSX.Element => {
   useEffect(() => {
     resumeAppliedRef.current = false;
     videoLoadedRef.current = false;
+    appliedPersistedLocalVideoRef.current = false;
   }, [activeEpisode?.id, activeEpisode?.link, activeEpisode?.sourceLink]);
+
+  // Auto-resume a remembered local video file for this episode (e.g. when
+  // opening this title again from Continue Watching) instead of forcing the
+  // user to pick the file again. Only applied once per episode so it never
+  // fights a manual server switch made later in the same session.
+  useEffect(() => {
+    if (appliedPersistedLocalVideoRef.current) {
+      return;
+    }
+    if (!syncedEpisodeMatches || !syncedContinueWatching?.localVideoUri) {
+      return;
+    }
+    appliedPersistedLocalVideoRef.current = true;
+    setSelectedStream({
+      server: 'Local Video',
+      link: syncedContinueWatching.localVideoUri,
+      type: 'local',
+    });
+  }, [syncedContinueWatching, syncedEpisodeMatches, setSelectedStream]);
 
   useEffect(() => {
     if (
@@ -707,6 +739,17 @@ const Player = ({route}: Props): React.JSX.Element => {
           type: 'local',
         });
         setShowSettings(false);
+        // Remember this file against the current continue-watching entry so
+        // reopening this same episode later resumes it automatically
+        // instead of prompting the picker again.
+        appliedPersistedLocalVideoRef.current = true;
+        if (continueWatchingId) {
+          setLocalVideoForContinueWatching(
+            continueWatchingId,
+            asset.uri,
+            asset.name || undefined,
+          );
+        }
         ToastAndroid.show(
           `Playing local file: ${asset.name || 'video'}`,
           ToastAndroid.SHORT,
@@ -716,7 +759,12 @@ const Player = ({route}: Props): React.JSX.Element => {
       console.log(err);
       ToastAndroid.show('Could not open the selected file', ToastAndroid.SHORT);
     }
-  }, [setSelectedStream, setShowSettings]);
+  }, [
+    continueWatchingId,
+    setLocalVideoForContinueWatching,
+    setSelectedStream,
+    setShowSettings,
+  ]);
 
   useEffect(() => {
     if (!remoteMediaClient) {
@@ -1163,7 +1211,7 @@ const Player = ({route}: Props): React.JSX.Element => {
   );
 
   // Show loading state
-  if (streamLoading && !isCasting) {
+  if (streamLoading && !isCasting && selectedStream?.type !== 'local') {
     return (
       <SafeAreaView
         edges={{right: 'off', top: 'off', left: 'off', bottom: 'off'}}
@@ -1192,7 +1240,7 @@ const Player = ({route}: Props): React.JSX.Element => {
   }
 
   // Show error state
-  if (streamError && !isCasting) {
+  if (streamError && !isCasting && selectedStream?.type !== 'local') {
     return (
       <SafeAreaView className="bg-black flex-1 justify-center items-center">
         <StatusBar translucent={true} hidden={true} />
@@ -1678,6 +1726,14 @@ const Player = ({route}: Props): React.JSX.Element => {
                         key={i}
                         onPress={() => {
                           setSelectedStream(track);
+                          appliedPersistedLocalVideoRef.current = true;
+                          if (continueWatchingId) {
+                            setLocalVideoForContinueWatching(
+                              continueWatchingId,
+                              undefined,
+                              undefined,
+                            );
+                          }
                           setShowSettings(false);
                           playerRef?.current?.resume();
                         }}>

--- a/src/screens/home/Player.tsx
+++ b/src/screens/home/Player.tsx
@@ -701,6 +701,36 @@ const Player = ({route}: Props): React.JSX.Element => {
   const handleVideoError = useCallback(
     (e: any) => {
       console.log('PlayerError', e);
+
+      if (selectedStream?.type === 'local') {
+        // The remembered local file is unreadable — most likely it was
+        // deleted, moved, or its access permission was revoked. Forget it
+        // and fall back to normal online sources instead of exiting the
+        // player. This usually fires before the background online search
+        // has finished, so: if results are already in, jump straight to
+        // the first one; otherwise clear the selection back to neutral so
+        // the existing "pick streamData[0] once it arrives" logic in
+        // useStream takes over as soon as it resolves.
+        if (activeEpisodeKey) {
+          if (selectedStream.link) {
+            releasePersistableUriPermission(selectedStream.link);
+          }
+          clearLocalVideoAssociation(activeEpisodeKey);
+        }
+        appliedPersistedLocalVideoRef.current = true;
+        ToastAndroid.show(
+          'Local video not found. Trying online sources...',
+          ToastAndroid.SHORT,
+        );
+        setSelectedStream(
+          streamData && streamData.length > 0
+            ? streamData[0]
+            : {server: '', link: '', type: ''},
+        );
+        setShowControls(true);
+        return;
+      }
+
       if (!switchToNextStream()) {
         ToastAndroid.show(
           'Video could not be played, try again later',
@@ -710,7 +740,16 @@ const Player = ({route}: Props): React.JSX.Element => {
       }
       setShowControls(true);
     },
-    [switchToNextStream, navigation, setShowControls],
+    [
+      activeEpisodeKey,
+      clearLocalVideoAssociation,
+      navigation,
+      selectedStream,
+      setSelectedStream,
+      setShowControls,
+      streamData,
+      switchToNextStream,
+    ],
   );
 
   // Let the user pick a local video file from the device and play it


### PR DESCRIPTION
When we played a local file, and the next time we started the same movie/episode from "continue watching" tab, we had to select the local file again.
I persisted the file location and its timeline. So it automatically starts from where we left.